### PR TITLE
fix(anomaly): scale position_mismatch threshold by gs × dt

### DIFF
--- a/retina_tracker/track.py
+++ b/retina_tracker/track.py
@@ -19,7 +19,6 @@ from .config import (
     get_mach1_doppler_threshold,
     ORBIT_HEADING_WINDOW,
     ORBIT_MIN_CUMULATIVE_DEG,
-    SPOOF_POSITION_EPSILON_DEG,
     SPOOF_MIN_SPEED_KTS,
     SPOOF_MIN_FROZEN_FRAMES,
     ALTITUDE_JUMP_THRESHOLD_FT,
@@ -292,17 +291,31 @@ class Track:
                 if total >= ORBIT_MIN_CUMULATIVE_DEG:
                     self.is_anomalous = True
                     self.anomaly_types.add("sustained_orbit")
-                    self.anomaly_detections.append({
-                        "timestamp": timestamp,
-                        "type": "sustained_orbit",
-                        "cumulative_heading_change_deg": total,
-                        "window_frames": len(self._heading_changes),
-                    })
+                    self.anomaly_detections.append(
+                        {
+                            "timestamp": timestamp,
+                            "type": "sustained_orbit",
+                            "cumulative_heading_change_deg": total,
+                            "window_frames": len(self._heading_changes),
+                        }
+                    )
                     return True
         return False
 
     def _check_position_mismatch_anomaly(self, detection, timestamp):
-        """Detect GPS spoofing: ADS-B position frozen while aircraft reports movement."""
+        """Detect GPS spoofing: ADS-B position frozen while aircraft reports movement.
+
+        Compares the *actual* per-frame position delta against the *expected*
+        delta from gs × dt. Flags only when actual motion is much smaller
+        than expected, so the check is not biased by frame rate or aircraft
+        speed.
+
+        The previous implementation used an absolute 220 m epsilon
+        (SPOOF_POSITION_EPSILON_DEG) without considering dt. At a 1 Hz
+        update rate any aircraft moving below ~440 kt produced a per-frame
+        delta smaller than the absolute threshold — flooding radar3 with
+        false-positive position_mismatch flags on every commercial flight.
+        """
         if not detection.get("adsb"):
             return False
         adsb = detection["adsb"]
@@ -318,20 +331,34 @@ class Track:
         if self._last_adsb_lat is not None and self._last_adsb_lon is not None:
             dlat = abs(lat - self._last_adsb_lat)
             dlon = abs(lon - self._last_adsb_lon)
-            if gs > SPOOF_MIN_SPEED_KTS and dlat < SPOOF_POSITION_EPSILON_DEG and dlon < SPOOF_POSITION_EPSILON_DEG:
-                self._adsb_frozen_count += 1
+            dt = None
+            if len(self.history["timestamps"]) > 1:
+                dt = (timestamp - self.history["timestamps"][-2]) / 1000.0
+            if dt is not None and 0 < dt < 60.0 and gs > SPOOF_MIN_SPEED_KTS:
+                # Expected per-frame delta from gs and dt, in degrees lat
+                # (≈111 km/deg). Treat both axes the same — adequate for
+                # the < 20 % "much-smaller-than-expected" comparison.
+                expected_motion_deg = (gs * KNOTS_TO_MS * dt) / 111_000.0
+                frozen_threshold = expected_motion_deg * 0.2
+                is_frozen = dlat < frozen_threshold and dlon < frozen_threshold
+                if is_frozen:
+                    self._adsb_frozen_count += 1
+                else:
+                    self._adsb_frozen_count = 0
             else:
                 self._adsb_frozen_count = 0
             if self._adsb_frozen_count >= SPOOF_MIN_FROZEN_FRAMES:
                 self.is_anomalous = True
                 self.anomaly_types.add("position_mismatch")
-                self.anomaly_detections.append({
-                    "timestamp": timestamp,
-                    "type": "position_mismatch",
-                    "frozen_frames": self._adsb_frozen_count,
-                    "reported_gs_kts": gs,
-                    "position_delta_deg": max(dlat, dlon),
-                })
+                self.anomaly_detections.append(
+                    {
+                        "timestamp": timestamp,
+                        "type": "position_mismatch",
+                        "frozen_frames": self._adsb_frozen_count,
+                        "reported_gs_kts": gs,
+                        "position_delta_deg": max(dlat, dlon),
+                    }
+                )
                 self._last_adsb_lat = lat
                 self._last_adsb_lon = lon
                 return True
@@ -374,12 +401,14 @@ class Track:
             old_hex = self.adsb_hex
             self.is_anomalous = True
             self.anomaly_types.add("identity_swap")
-            self.anomaly_detections.append({
-                "timestamp": timestamp,
-                "type": "identity_swap",
-                "old_hex": old_hex,
-                "new_hex": new_hex,
-            })
+            self.anomaly_detections.append(
+                {
+                    "timestamp": timestamp,
+                    "type": "identity_swap",
+                    "old_hex": old_hex,
+                    "new_hex": new_hex,
+                }
+            )
             # Advance adsb_hex so subsequent frames don't re-trigger
             self.adsb_hex = new_hex
             self._identity_mismatch_count = 0
@@ -415,13 +444,15 @@ class Track:
             if dalt > ALTITUDE_JUMP_THRESHOLD_FT:
                 self.is_anomalous = True
                 self.anomaly_types.add("altitude_jump")
-                self.anomaly_detections.append({
-                    "timestamp": timestamp,
-                    "type": "altitude_jump",
-                    "altitude_change_ft": dalt,
-                    "old_alt_ft": self._last_alt_baro,
-                    "new_alt_ft": alt_baro,
-                })
+                self.anomaly_detections.append(
+                    {
+                        "timestamp": timestamp,
+                        "type": "altitude_jump",
+                        "altitude_change_ft": dalt,
+                        "old_alt_ft": self._last_alt_baro,
+                        "new_alt_ft": alt_baro,
+                    }
+                )
                 self._last_alt_baro = alt_baro
                 return True
         self._last_alt_baro = alt_baro
@@ -456,14 +487,16 @@ class Track:
                 if acceleration > ANOMALOUS_ACCEL_MS2:
                     self.is_anomalous = True
                     self.anomaly_types.add("anomalous_acceleration")
-                    self.anomaly_detections.append({
-                        "timestamp": timestamp,
-                        "type": "anomalous_acceleration",
-                        "acceleration_ms2": acceleration,
-                        "acceleration_g": round(acceleration / 9.81, 1),
-                        "velocity_change_ms": dv,
-                        "time_delta_sec": dt,
-                    })
+                    self.anomaly_detections.append(
+                        {
+                            "timestamp": timestamp,
+                            "type": "anomalous_acceleration",
+                            "acceleration_ms2": acceleration,
+                            "acceleration_g": round(acceleration / 9.81, 1),
+                            "velocity_change_ms": dv,
+                            "time_delta_sec": dt,
+                        }
+                    )
                     result = True
 
         self._anomalous_accel_last_velocity_ms = velocity_ms
@@ -499,13 +532,15 @@ class Track:
             if duration_s >= LONG_HOVER_MIN_DURATION_S:
                 self.is_anomalous = True
                 self.anomaly_types.add("long_hover")
-                self.anomaly_detections.append({
-                    "timestamp": timestamp,
-                    "type": "long_hover",
-                    "hover_duration_s": round(duration_s, 1),
-                    "anchor_lat": self._hover_anchor_lat,
-                    "anchor_lon": self._hover_anchor_lon,
-                })
+                self.anomaly_detections.append(
+                    {
+                        "timestamp": timestamp,
+                        "type": "long_hover",
+                        "hover_duration_s": round(duration_s, 1),
+                        "anchor_lat": self._hover_anchor_lat,
+                        "anchor_lon": self._hover_anchor_lon,
+                    }
+                )
                 # Reset anchor to avoid repeated firing every frame
                 self._hover_anchor_lat = lat
                 self._hover_anchor_lon = lon

--- a/tests/test_anomaly_detection.py
+++ b/tests/test_anomaly_detection.py
@@ -489,6 +489,129 @@ def test_direction_change_anomaly():
     print("\n✓ Test 6 passed: Direction change anomaly detection working")
 
 
+def test_position_mismatch_no_false_positive_on_slow_aircraft():
+    """A slow aircraft moving consistently must NOT trigger position_mismatch.
+
+    Regression test for radar3 false-positive flood.  The original
+    `_check_position_mismatch_anomaly` used a fixed 220 m epsilon without
+    accounting for frame rate, so any aircraft moving < ~440 kt at 1 Hz
+    update rate would be flagged as 'GPS spoofed' (its per-frame position
+    delta fell below the absolute threshold even though it matched the
+    reported groundspeed).
+    """
+    print("\n" + "=" * 60)
+    print("Test 7: position_mismatch no false positive on slow aircraft")
+    print("=" * 60)
+
+    # Aircraft at 100 kt, heading 90° (eastbound), sampled at 1 Hz.
+    # 100 kt = 51.4 m/s → expected lon change per frame ≈ 0.00056°
+    # at lat = 33.8°. Far below the old 0.002° epsilon → was flagged frozen.
+    detections = []
+    for i in range(8):
+        lon = -84.5 + (51.4 * i) / (111_000.0 * 0.83)  # eastward at 51.4 m/s
+        detections.append(
+            {
+                "timestamp": 1700000000000 + i * 1000,  # 1 Hz frames
+                "delay": [50.0 + i * 0.2],
+                "doppler": [80.0 + i * 0.5],
+                "snr": [15.0],
+                "adsb": [
+                    {
+                        "hex": "slow01",
+                        "lat": 33.8,
+                        "lon": lon,
+                        "alt_baro": 5000,
+                        "gs": 100,
+                        "track": 90,
+                    }
+                ],
+            }
+        )
+
+    with open("test_slow_aircraft.detection", "w") as f:
+        json.dump(detections, f)
+
+    config = {
+        "tracker": {"m_threshold": 3, "n_window": 5, "n_delete": 10, "min_snr": 7.0, "gate_threshold": 9.0},
+        "adsb": {
+            "enabled": True,
+            "priority": True,
+            "reference_location": {"latitude": 33.8, "longitude": -84.5, "altitude": 300},
+            "initial_covariance": {"position": 100.0, "velocity": 5.0},
+        },
+    }
+
+    set_config(config)
+    tracker = process_detections("test_slow_aircraft.detection")
+    confirmed = tracker.get_confirmed_tracks()
+    os.remove("test_slow_aircraft.detection")
+
+    assert len(confirmed) > 0, "Should track the slow aircraft"
+    track = confirmed[0]
+    print(f"  Is anomalous: {track.is_anomalous}")
+    print(f"  Anomaly types: {sorted(track.anomaly_types)}")
+    assert "position_mismatch" not in track.anomaly_types, (
+        "Slow aircraft moving consistent with its groundspeed must NOT be "
+        "flagged as position_mismatch — the actual per-frame motion matches "
+        "the reported gs."
+    )
+    print("✓ Test 7 passed: no false-positive on slow aircraft")
+
+
+def test_position_mismatch_true_positive_on_frozen_adsb():
+    """A truly frozen ADS-B feed (position never changes, gs > threshold) MUST flag."""
+    print("\n" + "=" * 60)
+    print("Test 8: position_mismatch fires when ADS-B is genuinely frozen")
+    print("=" * 60)
+
+    # Aircraft reports gs = 300 kt but position is locked.
+    detections = []
+    for i in range(8):
+        detections.append(
+            {
+                "timestamp": 1700000000000 + i * 1000,
+                "delay": [50.0 + i * 0.2],
+                "doppler": [80.0 + i * 0.5],
+                "snr": [15.0],
+                "adsb": [
+                    {
+                        "hex": "spoof1",
+                        "lat": 33.8,  # FROZEN
+                        "lon": -84.5,  # FROZEN
+                        "alt_baro": 30000,
+                        "gs": 300,  # claims to be moving fast
+                        "track": 90,
+                    }
+                ],
+            }
+        )
+
+    with open("test_frozen_adsb.detection", "w") as f:
+        json.dump(detections, f)
+
+    config = {
+        "tracker": {"m_threshold": 3, "n_window": 5, "n_delete": 10, "min_snr": 7.0, "gate_threshold": 9.0},
+        "adsb": {
+            "enabled": True,
+            "priority": True,
+            "reference_location": {"latitude": 33.8, "longitude": -84.5, "altitude": 300},
+            "initial_covariance": {"position": 100.0, "velocity": 5.0},
+        },
+    }
+
+    set_config(config)
+    tracker = process_detections("test_frozen_adsb.detection")
+    confirmed = tracker.get_confirmed_tracks()
+    os.remove("test_frozen_adsb.detection")
+
+    assert len(confirmed) > 0, "Should track the spoofed aircraft"
+    track = confirmed[0]
+    print(f"  Is anomalous: {track.is_anomalous}")
+    print(f"  Anomaly types: {sorted(track.anomaly_types)}")
+    assert "position_mismatch" in track.anomaly_types, "Frozen ADS-B with gs > 50 kts must trigger position_mismatch"
+    print("✓ Test 8 passed: genuine spoof detected")
+
+
 if __name__ == "__main__":
     try:
         test_normal_aircraft()
@@ -497,6 +620,8 @@ if __name__ == "__main__":
         test_anomaly_threshold()
         test_acceleration_anomaly()
         test_direction_change_anomaly()
+        test_position_mismatch_no_false_positive_on_slow_aircraft()
+        test_position_mismatch_true_positive_on_frozen_adsb()
         print("\n" + "=" * 60)
         print("SUCCESS: All anomaly detection tests passed! ✓")
         print("=" * 60)


### PR DESCRIPTION
## Summary

The position_mismatch (GPS spoof) check used a fixed 220 m epsilon (`SPOOF_POSITION_EPSILON_DEG`) without considering dt. At 1 Hz update rate any aircraft moving below ~440 kt produced a per-frame delta smaller than that absolute threshold, so all commercial flights at 200–400 kt were continuously flagged as 'GPS spoofed' on real radar nodes.

On staging right now, **5 of 6 radar3 anomalies are this false positive** (a0c94e at 104 kt, adfd76 at 147 kt, a441c9 at 165 kt, a0f60d at 90 kt, ae511d at 117 kt — all flagged \`position_mismatch\` despite normal flight).

The fix scales the threshold to expected motion (gs × dt). 'Frozen' is now actual delta < 20 % of expected delta. A genuinely spoofed feed (position locked, gs > 50 kt) still produces dlat/dlon ≈ 0 which is well below the 20 % bound regardless of speed.

## Test plan

- [x] New: \`test_position_mismatch_no_false_positive_on_slow_aircraft\` — 100 kt eastbound aircraft at 1 Hz, **failed before fix**, passes after.
- [x] New: \`test_position_mismatch_true_positive_on_frozen_adsb\` — 300 kt reported, position locked → still flagged.
- [x] All 21 existing tracker tests pass.
- [x] Lint + format clean.
- [ ] After deploy: radar3 anomaly count drops from ~30 % to small single digits (real spoof/erratic flights only).