### PR TITLE
Add Docker build/publish CI, first packaged release v0.1.1

### DIFF
--- a/.github/workflows/build-retina-tracker.yml
+++ b/.github/workflows/build-retina-tracker.yml
@@ -1,0 +1,118 @@
+name: build-retina-tracker
+
+on:
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Image tag (e.g., v1.0.0, dev)"
+        required: true
+        default: dev
+      publish:
+        description: "Push to GHCR?"
+        required: true
+        default: "false"
+        type: choice
+        options: ["false", "true"]
+  workflow_call:
+    inputs:
+      tag:
+        required: true
+        type: string
+      publish:
+        required: false
+        type: string
+        default: "false"
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    permissions: { contents: read, packages: write }
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: docker/setup-qemu-action@v3
+
+      - uses: docker/setup-buildx-action@v3
+
+      - uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build retina-tracker
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: ./Dockerfile
+          platforms: linux/arm64
+          push: false
+          load: true
+          tags: retina-tracker:${{ inputs.tag }}
+          cache-from: type=registry,ref=ghcr.io/offworldlabs/retina-tracker:cache
+          cache-to: type=registry,ref=ghcr.io/offworldlabs/retina-tracker:cache,mode=max
+          labels: |
+            org.opencontainers.image.source=${{ github.repository }}
+            org.opencontainers.image.revision=${{ github.sha }}
+
+      - name: Export image to tarball
+        run: docker save retina-tracker:${{ inputs.tag }} -o /tmp/retina-tracker.tar
+
+      - name: Upload image artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: retina-tracker-image
+          path: /tmp/retina-tracker.tar
+          retention-days: 1
+
+  test:
+    needs: build
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: docker/setup-qemu-action@v3  # needed: image is linux/arm64, runner is x86
+
+      - name: Download retina-tracker image
+        uses: actions/download-artifact@v4
+        with:
+          name: retina-tracker-image
+          path: /tmp
+
+      - name: Load image
+        run: |
+          docker load -i /tmp/retina-tracker.tar
+          echo "Loaded images:"
+          docker images | grep ${{ inputs.tag }}
+
+      - name: Run unit tests inside the image
+        run: |
+          docker run --rm --entrypoint sh retina-tracker:${{ inputs.tag }} -c '
+            pip install --no-cache-dir pytest &&
+            pytest -q
+          '
+
+  publish:
+    needs: test
+    if: ${{ inputs.publish == 'true' }}
+    runs-on: ubuntu-latest
+    permissions: { contents: read, packages: write }
+
+    steps:
+      - uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Download image
+        uses: actions/download-artifact@v4
+        with:
+          name: retina-tracker-image
+          path: /tmp
+
+      - name: Load and push retina-tracker
+        run: |
+          docker load -i /tmp/retina-tracker.tar
+          docker tag retina-tracker:${{ inputs.tag }} ghcr.io/offworldlabs/retina-tracker:${{ inputs.tag }}
+          docker push ghcr.io/offworldlabs/retina-tracker:${{ inputs.tag }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,48 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - 'v*.*.*'      # Release tags e.g. v0.1.0, v1.0.0
+      - 'v*.*.*-rc*'  # Release candidates e.g. v0.3.0-rc1
+      - 'dev'         # Development builds
+  workflow_dispatch:  # Manual trigger
+    inputs:
+      version:
+        description: "Release version (e.g., v1.0.0, dev)"
+        required: true
+
+jobs:
+  build-retina-tracker:
+    name: Build retina-tracker
+    uses: ./.github/workflows/build-retina-tracker.yml
+    with:
+      tag: ${{ github.event_name == 'push' && github.ref_name || inputs.version }}
+      publish: "true"
+
+  create-release:
+    name: Create GitHub Release
+    needs: [build-retina-tracker]
+    # Only create releases for proper version tags (not dev or rc)
+    if: github.event_name == 'push' && startsWith(github.ref_name, 'v') && !contains(github.ref_name, '-')
+    runs-on: ubuntu-latest
+    permissions: { contents: write }
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Create Release
+        uses: softprops/action-gh-release@v2
+        with:
+          generate_release_notes: true
+          body: |
+            ## Docker Image Published
+
+            Built, tested, and published to GitHub Container Registry:
+
+            - `ghcr.io/offworldlabs/retina-tracker:${{ github.ref_name }}`
+
+            Pull with:
+            ```bash
+            docker pull ghcr.io/offworldlabs/retina-tracker:${{ github.ref_name }}
+            ```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "retina-tracker"
-version = "0.1.0"
+version = "0.1.1"
 description = "Multi-target tracker for bistatic passive radar with anomaly detection"
 requires-python = ">=3.10"
 dependencies = [


### PR DESCRIPTION
## Summary
- Adds `.github/workflows/build-retina-tracker.yml` + `release.yml`, mirroring blah2-arm's reusable build→test→publish pattern (x86 runner + QEMU cross-build for linux/arm64, since retina-tracker's deps all ship prebuilt manylinux_aarch64 wheels).
- No source/Dockerfile changes — both were already correct for this use.
- Bumps `pyproject.toml` to 0.1.1 and publishes the first real Docker image: `ghcr.io/offworldlabs/retina-tracker:v0.1.1`. The existing `v0.1.0` git tag predates this work (points at 8b386d6, before the Dockerfile/CI existed) and was never published as a Docker image — bumping avoids the git tag and Docker tag pointing at different commits.

## Why
Needed so retina-tracker can run as a standalone sidecar container (consumed by retina-gui's tracker-preview feature) instead of only ever being pip-installed in-process. See offworldlabs/retina-gui#<TBD> and offworldlabs/retina-node#<TBD>.

## Test plan
- [x] CI build→test→publish ran clean for both `dev` and `v0.1.1` tags
- [x] `docker pull ghcr.io/offworldlabs/retina-tracker:v0.1.1` confirmed working from a real node
- [x] Live-verified end-to-end on jonathan-node-2 (see companion PRs for full verification summary)

🤖 Generated with [Claude Code](https://claude.com/claude-code)