### PR TITLE
Cap coasting covariance growth to stop gate inflation

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -6,6 +6,7 @@ tracker:
   m_threshold: 4          # Associations needed to confirm track
   n_window: 6             # Window for M-of-N logic
   n_delete: 10            # Missed frames before deletion
+  n_coast: 3              # Missed frames before the association gate stops widening
   min_snr: 7.0            # Detection threshold (dB)
   gate_threshold: 9.0     # Chi-squared gate (99% confidence)
   detection_window: 20    # Rolling detection window for streaming output

--- a/retina_tracker/config.py
+++ b/retina_tracker/config.py
@@ -127,7 +127,8 @@ def N_DELETE():
     return _get_param("tracker", "n_delete", 10)
 
 
-N_COAST = 3
+def N_COAST():
+    return _get_param("tracker", "n_coast", 3)
 
 
 def GATE_THRESHOLD():

--- a/retina_tracker/track.py
+++ b/retina_tracker/track.py
@@ -13,6 +13,7 @@ from .config import (
     MAX_NORMAL_ACCEL_MS2,
     SPEED_OF_LIGHT,
     M_THRESHOLD,
+    N_COAST,
     N_DELETE,
     N_WINDOW,
     _get_param,
@@ -611,7 +612,13 @@ class Track:
 
     def predict(self, dt):
         self.kf.dt = dt
-        self.state, self.covariance = self.kf.predict(self.state, self.covariance)
+        state_pred, cov_pred = self.kf.predict(self.state, self.covariance)
+        self.state = state_pred
+        # Freeze covariance growth once coasting exceeds N_COAST so the
+        # association gate stops inflating toward unrelated detections while
+        # the track dead-reckons on toward its N_DELETE deletion point.
+        if self.n_missed <= N_COAST():
+            self.covariance = cov_pred
 
     def update(self, detection, timestamp, frame=0):
         measurement = np.array([detection["delay"], detection["doppler"]])

--- a/tests/test_coasting.py
+++ b/tests/test_coasting.py
@@ -1,0 +1,86 @@
+"""Tests for coasting covariance growth.
+
+A track that misses several detections in a row keeps predicting forward
+(dead reckoning) so it can still be deleted cleanly at n_delete, but its
+association gate must not keep inflating the whole time — otherwise a
+long-coasting track eventually gates onto an unrelated stray detection far
+from its true predicted position, producing a visible jump in the track's
+path that then jumps back once it reacquires the real target.
+"""
+
+from retina_tracker.config import set_config
+from retina_tracker.tracker import Tracker
+
+
+def build_config(**overrides):
+    config = {
+        "tracker": {
+            "m_threshold": 4,
+            "n_window": 20,
+            "n_delete": 20,
+            "n_coast": 3,
+            "min_snr": 7.0,
+            "gate_threshold": 9.0,
+            "detection_window": 20,
+        },
+        "process_noise": {"delay": 0.1, "doppler": 0.5},
+        "tracklet": {"max_delay_residual": 2.0, "max_doppler_residual": 10.0, "max_time_span": 3.0},
+        "adsb": {
+            "enabled": False,
+            "priority": True,
+            "reference_location": None,
+            "initial_covariance": {"position": 100.0, "velocity": 5.0},
+        },
+        "radar": {"center_frequency": 200000000},
+    }
+    config["tracker"].update(overrides)
+    return config
+
+
+def make_coasting_track(n_coast):
+    config = build_config(n_coast=n_coast)
+    set_config(config)
+    tracker = Tracker(config=config)
+    tracker.process_frame([{"delay": 10.0, "doppler": -70.0, "snr": 15.0}], 0)
+    for i in range(1, 9):
+        tracker.process_frame([], i * 500)
+    return tracker
+
+
+def test_covariance_growth_freezes_after_n_coast():
+    delay_variances = []
+    doppler_variances = []
+    config = build_config(n_coast=3)
+    set_config(config)
+    tracker = Tracker(config=config)
+    tracker.process_frame([{"delay": 10.0, "doppler": -70.0, "snr": 15.0}], 0)
+    for i in range(1, 9):
+        tracker.process_frame([], i * 500)
+        track = tracker.tracks[0]
+        delay_variances.append(track.covariance[0, 0])
+        doppler_variances.append(track.covariance[2, 2])
+
+    # Grows for the first N_COAST + 1 missed frames...
+    assert delay_variances[0] < delay_variances[1] < delay_variances[2] < delay_variances[3]
+    assert doppler_variances[0] < doppler_variances[1] < doppler_variances[2] < doppler_variances[3]
+    # ...then freezes for every frame after that.
+    assert all(v == delay_variances[3] for v in delay_variances[3:])
+    assert all(v == doppler_variances[3] for v in doppler_variances[3:])
+
+
+def test_long_coasting_track_rejects_stray_detection():
+    """A detection far from the predicted position must not be swallowed
+    just because the track has been coasting for a while."""
+    tracker = make_coasting_track(n_coast=3)
+    stray = {"delay": 30.0, "doppler": -70.0, "snr": 15.0}
+
+    assert tracker._associate([stray]) == []
+
+
+def test_long_coasting_track_still_accepts_a_true_reacquisition():
+    """The cap must not make coasting tracks impossible to reacquire —
+    a detection close to the predicted position still associates."""
+    tracker = make_coasting_track(n_coast=3)
+    nearby = {"delay": 10.5, "doppler": -69.0, "snr": 15.0}
+
+    assert tracker._associate([nearby]) == [(0, 0)]


### PR DESCRIPTION
## Summary
- Users reported tracks that "jump to a hit way off in the middle of nowhere, then jump back to the flight path." Root cause: `Track.predict()` grew the Kalman covariance by the full process noise every frame, including while coasting through missed detections, with nothing capping the growth — after ~10 consecutive misses the association gate could balloon to 15-30 delay/Doppler units, wide enough to snap onto unrelated clutter or a crossing track.
- `N_COAST` was already declared in `config.py` for exactly this purpose but was dead code, never wired into anything. This PR turns it into a config-driven parameter (matching `M_THRESHOLD()`, `N_WINDOW()`, etc.) and uses it in `Track.predict()` to freeze covariance growth once a track has missed more than `N_COAST` (default 3) frames in a row — state prediction and deletion (`N_DELETE`) are unaffected.

## Test plan
- [x] `ruff check retina_tracker/ tests/ --select E,F,W --line-length 120` — passes
- [x] `ruff format --check retina_tracker/ tests/` — passes
- [x] `pytest tests/ -v` — 27 passed, 1 pre-existing unrelated skip
- [x] New `tests/test_coasting.py`: covariance growth freezes after `N_COAST`, a stray detection far from the predicted position is correctly rejected once coasting exceeds the cap, and a genuine nearby reacquisition still associates normally
- [x] Verified as a live hotfix on production hardware (patched a running container in place): process stayed healthy with zero errors, and produced clean confirmed tracks through the patched path before the container was later recreated by unrelated work and reverted to the base image — deployment mechanics confirmed, but no specific real-world "would have skewed, didn't" event was directly observed
- [ ] Being handed off for live field testing on hardware — flagging so whoever picks this up knows to watch for the original skew symptom (a track visibly jumping to an isolated detection and back) no longer occurring

🤖 Generated with [Claude Code](https://claude.com/claude-code)