### PR TITLE
Run ruff through pre-commit rather than as separate CI steps

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,13 +23,7 @@ jobs:
       - name: Install dependencies
         run: uv pip install --system -r requirements.txt -r requirements-dev.txt
 
-      - name: Ruff lint
-        run: ruff check .
-
-      - name: Ruff format check
-        run: ruff format --check .
-
-      - name: Dead code
+      - name: Lint (pre-commit)
         run: pre-commit run --all-files --show-diff-on-failure
 
       - name: Pytest

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,10 +1,14 @@
-# The dead-code gate lives in offworldlabs/ops and is pinned here. Do not
-# vendor it back into this repo. See 86cb417ty.
-#
-# ruff is deliberately still a separate CI step rather than a hook; aligning
-# this repo with claude-shared's ci-python.yml is a separate piece of work.
+# ruff and the dead-code gate both run through pre-commit, so `pre-commit run
+# --all-files` locally reproduces CI exactly. See 86cb43xya.
 repos:
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.16.2
+    hooks:
+      - id: ruff
+      - id: ruff-format
+
   - repo: https://github.com/offworldlabs/ops
-    rev: dead-code-v1.0
+    rev: hooks-v1.0
     hooks:
       - id: dead-code
+      - id: ruff-config

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,6 @@ dependencies = [
 [project.optional-dependencies]
 dev = [
     "pytest>=8.0",
-    "ruff>=0.8.0",
 ]
 
 [tool.setuptools.packages.find]
@@ -29,8 +28,10 @@ retina_tracker = ["*.yaml"]
 testpaths = ["tests"]
 pythonpath = ["."]
 
-# Shared ruff standard for offworldlabs Python repos.
-# Keep in sync across repos; see offworldlabs/ops for the canonical copy.
+# Shared ruff standard for offworldlabs Python repos. The keys below are checked
+# against offworldlabs/ops:ruff-shared.toml by the `ruff-config` pre-commit hook
+# — edit them there, not here. target-version is deliberately per-repo and
+# tracks this package's requires-python.
 [tool.ruff]
 line-length = 120
 target-version = "py310"


### PR DESCRIPTION
Part of [86cb43xya](https://app.clickup.com/t/86cb43xya). Smallest of the six — this repo was already closest to `claude-shared`'s scaffolded `ci-python.yml`.

## What changed

It already had `setup-uv` and already ran `pytest`, so this only moves ruff into pre-commit:

- `Ruff lint` and `Ruff format check` steps removed; the remaining hook step becomes `Lint (pre-commit)` and now runs all four hooks
- `.pre-commit-config.yaml` gains `ruff` + `ruff-format` (`rev: v0.16.2`) and `ruff-config` alongside `dead-code`, both from `ops` at `rev: hooks-v1.0`
- Drops the redundant unpinned `ruff>=0.8.0` from the `dev` extra — ruff is now pinned by the hook, and an unpinned duplicate contradicts the pinning this repo's own CI comment argues for

`pre-commit run --all-files` now reproduces the lint half of CI exactly.

## Deliberately unchanged

- **No formatting sweep.** `ruff format --check` reports everything already formatted — this repo has enforced format in CI all along, unlike the other five. Zero files touched.
- **No `vulture` added to the install line.** The other repos needed that because they install via `-e '.[dev]'` and do not declare vulture; this one gets it from `requirements-dev.txt`, which already pins `vulture==2.14`.
- **`[tool.ruff.format]` kept.** This is the only repo with that block. The new `ruff-config` hook is permissive by design — canonical keys must match, but local additions are not drift. Removing it to look like the others would be the wrong call, and this PR is a useful real-world check that the rule tolerates it.

## The ruff comment is now true

`pyproject.toml` claimed *"see offworldlabs/ops for the canonical copy"*. `ops` had never held one — the same false claim [86cb417ty](https://app.clickup.com/t/86cb417ty) fixed for the dead-code script. `ops` now ships `ruff-shared.toml` plus a hook that checks this repo against it, comparing semantically and ignoring `target-version`, which legitimately tracks `requires-python`.

No ruff values changed.

## Verification

All four hooks pass with nothing to reformat; `52 passed`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013ZcazeseXVpu8XrYA2tE1V